### PR TITLE
Fix Jacdac pxt.json

### DIFF
--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -5,7 +5,7 @@
         "core": "*",
         "radio": "*",
         "microphone": "*",
-        "pxt-k-bit": "github:pelikhan/pxt-k-bit",
+        "pxt-k-bit": "github:mworkfun/pxt-k-bit",
         "jacdac": "github:microsoft/pxt-jacdac#v0.10.41",
         "jacdac-light-level": "github:microsoft/pxt-jacdac/light-level#v0.10.41",
         "jacdac-led": "github:microsoft/pxt-jacdac/led#v0.10.41",


### PR DESCRIPTION
Sorry, I missed this change for the Jacdac update.

Would it be possible to create a release for this repository?